### PR TITLE
Remove inline-block styling from standard img element

### DIFF
--- a/build/assets/styles.css
+++ b/build/assets/styles.css
@@ -367,11 +367,6 @@
     .slds .sfdo-kb__body li table + .sfdo-kb-img,
     .hub-primary-theme .sfdo-kb__body li table + .sfdo-kb-img {
       margin-top: 0; }
-    .slds .sfdo-kb__body li .sfdo-kb-img:first-child:last-child,
-    .hub-primary-theme .sfdo-kb__body li .sfdo-kb-img:first-child:last-child {
-      margin-top: 0;
-      display: inline-block;
-      vertical-align: top; }
     .slds .sfdo-kb__body li .sfdo-kb-note,
     .hub-primary-theme .sfdo-kb__body li .sfdo-kb-note {
       margin-top: 0.5rem;

--- a/build/index.html
+++ b/build/index.html
@@ -837,6 +837,11 @@
 
                     <h2>Changes</h2>
 
+                    <h3>2020-05-11</h3>
+                    <ul>
+                        <li>Remove inline-block styling from standard img element</li>
+                    </ul>
+
                     <h3>2020-04-17</h3>
                     <ul>
                         <li>Add code block styling</li>

--- a/src/_main.scss
+++ b/src/_main.scss
@@ -100,14 +100,6 @@
 
     @include adjacentSpacing($spacing-x-small, "#{$sfdo-css-prefix}-img");
 
-    #{$sfdo-css-prefix}-img {
-      &:first-child:last-child {
-        margin-top: 0;
-        display: inline-block;
-        vertical-align: top;
-      }
-    }
-
     @include adjacentSpacing($spacing-x-small, "#{$sfdo-css-prefix}-note");
 
     #{$sfdo-css-prefix}-note {


### PR DESCRIPTION
For unknown reasons, there is a style being applied to standard img tag containers that forces inline-block styling (in some scenarios). This goes against how the product doc team styles actual inline-block images (using the `sfdo-kb-img_inline` class).

This change removes the unnecessary inline styling from the standard img tag containers to align with the product doc team's practice.