### PR TITLE
styling for pricing table

### DIFF
--- a/build/assets/styles.css
+++ b/build/assets/styles.css
@@ -596,6 +596,10 @@
     .hub-primary-theme .sfdo-kb__body table tbody td,
     .hub-primary-theme .sfdo-kb__body table tbody th {
       border-top: 1px solid #dddbda; }
+  .slds .sfdo-kb__body .sfdo-kb__pricing-table table,
+  .hub-primary-theme .sfdo-kb__body .sfdo-kb__pricing-table table {
+    border-left-style: none;
+    border-right-style: none; }
   .slds .sfdo-kb__body .sfdo-kb-scrollable_table,
   .hub-primary-theme .sfdo-kb__body .sfdo-kb-scrollable_table {
     border: 1px solid rgba(221, 219, 218, 0.5);

--- a/build/index.html
+++ b/build/index.html
@@ -427,6 +427,21 @@
                         </table>
                     </div>
 
+                    <h3>Pricing Table</h3>
+
+                    <div class="slds-table sfdo-kb__pricing-table">
+                        <table>
+                            <tbody>
+                                <tr>
+                                  <td>Available in: Lightning Experience</td>
+                                </tr>
+                                <tr>
+                                  <td>Available in: <strong>Accounting Subledger Starter</strong> and <strong>Growth </strong>Editions</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>                    
+
                     <h3>Table With Caption</h3>
 
                     <div class="slds-scrollable sfdo-kb-scrollable sfdo-kb-scrollable_table">

--- a/build/index.html
+++ b/build/index.html
@@ -429,14 +429,14 @@
 
                     <h3>Pricing Table</h3>
 
-                    <div class="slds-table sfdo-kb__pricing-table">
+                    <div class="sfdo-kb__pricing-table">
                         <table>
                             <tbody>
                                 <tr>
                                   <td>Available in: Lightning Experience</td>
                                 </tr>
                                 <tr>
-                                  <td>Available in: <strong>Accounting Subledger Starter</strong> and <strong>Growth </strong>Editions</td>
+                                  <td>Available in: <strong>Accounting Subledger Starter</strong>,<strong>Accounting Subledger Premium</strong>, <strong>Accounting Subledger Platinum</strong>, <strong>Accounting Subledger Diamond</strong> and <strong>Growth </strong>Editions</td>
                                 </tr>
                             </tbody>
                         </table>

--- a/src/_main.scss
+++ b/src/_main.scss
@@ -295,6 +295,13 @@
     }
   }
 
+  #{$sfdo-css-prefix}__pricing-table {
+    table {
+      border-left-style: none;
+      border-right-style: none;
+    }    
+  }
+
   /**
    * Scrollable
    */


### PR DESCRIPTION
Created new class `sfdo-kb__pricing-table` to mimic the same style that is applied to pricing table in standard help articles([example](https://help.salesforce.com/articleView?id=sf.briefcase_builder_overview.htm&type=5))

Here is an example of table that uses this new styling class: 